### PR TITLE
events/rudderstack

### DIFF
--- a/lib/WebService/Async/Segment.pm
+++ b/lib/WebService/Async/Segment.pm
@@ -188,25 +188,17 @@ sub method_call {
         )->then(
         sub {
             my $result = shift;
-
+print $result->code . "\n";
             $log->tracef('Segment response for %s method received: %s', $method, $result);
 
             my $response_str = $result->content;
-            return Future->fail('RequestFailed', 'segment', $response_str) unless $response_str =~ /{\X+}/;
 
-            my $response;
-            try {
-                $response = decode_json_utf8($response_str);
-            }
-            catch {
-                return Future->fail('InvalidResponse', 'segment', $response_str);
-            }
-
-            if ($response->{success}) {
+            if ($result->code == 200) {
                 $log->tracef('Segment %s method call finished successfully.', $method);
 
-                return Future->done($response->{success});
+                return Future->done(1);
             }
+
             return Future->fail('RequestFailed', 'segment', $response_str);
         }
         )->on_fail(

--- a/lib/WebService/Async/Segment.pm
+++ b/lib/WebService/Async/Segment.pm
@@ -188,7 +188,7 @@ sub method_call {
         )->then(
         sub {
             my $result = shift;
-print $result->code . "\n";
+
             $log->tracef('Segment response for %s method received: %s', $method, $result);
 
             my $response_str = $result->content;

--- a/t/customer.t
+++ b/t/customer.t
@@ -19,6 +19,8 @@ my $call_req;
 my %call_http_args;
 my $mock_http     = Test::MockModule->new('Net::Async::HTTP');
 my $mock_response = '{"success":1}';
+my $code;
+
 $mock_http->mock(
     'POST' => sub {
         (undef, $call_uri, $call_req, %call_http_args) = @_;
@@ -26,10 +28,16 @@ $mock_http->mock(
         return $mock_response if $mock_response->isa('Future');
 
         my $response = $mock_response;
-        $response = '404 Not Found' unless $call_uri =~ /(identify|track)$/;
+        $code = 200;
+
+        unless ($call_uri =~ /(identify|track)$/) {
+            $response = '404 Not Found';
+            $code = 404;
+        }
 
         my $res = Test::MockObject->new();
         $res->mock(content => sub { $response });
+        $res->mock(code => sub { $code });
         Future->done($res);
     });
 


### PR DESCRIPTION
the API documentation suggests to check for http status code 200 on success (nothing about json response), I've seen Rudderstack prints out an `OK` message on success (no json there), this change makes this wrapper compatible with Rudderstack.